### PR TITLE
feat: localize date picker

### DIFF
--- a/frontend/src/components/DatePickerField.tsx
+++ b/frontend/src/components/DatePickerField.tsx
@@ -1,7 +1,9 @@
 import { useFormikContext } from 'formik';
 import { useState } from 'react';
-import DatePicker from 'react-datepicker';
+import DatePicker, { registerLocale } from 'react-datepicker';
 import 'react-datepicker/dist/react-datepicker.css';
+import sv from 'date-fns/locale/sv';
+registerLocale('sv', sv);
 
 import TimeIcon from '../icons/TimeIcon';
 
@@ -38,6 +40,7 @@ const DatePickerField = ({
         }} */
         showTimeSelect
         dateFormat="Pp"
+        locale="sv"
         className="w-full rounded-md bg-pm-grey py-2 pl-8 pr-3 text-xs"
       />
       <TimeIcon

--- a/frontend/src/components/DatePickerField.tsx
+++ b/frontend/src/components/DatePickerField.tsx
@@ -41,6 +41,12 @@ const DatePickerField = ({
         showTimeSelect
         dateFormat="Pp"
         locale="sv"
+        timeCaption="Tid"
+        previousMonthAriaLabel="Tidigare månad"
+        previousMonthButtonLabel="Tidigare månad"
+        nextMonthAriaLabel="Nästa månad"
+        nextMonthButtonLabel="Nästa månad"
+        chooseDayAriaLabelPrefix="Välj"
         className="w-full rounded-md bg-pm-grey py-2 pl-8 pr-3 text-xs"
       />
       <TimeIcon


### PR DESCRIPTION
This PR localizes the date format and misc labels for the date picker (`react-datepicker`).

<img width="328" alt="Skärmavbild 2022-08-03 kl  11 06 44" src="https://user-images.githubusercontent.com/51208557/182570305-d8fd9ab7-16c7-4644-acc2-b3f55439cbb1.png">
